### PR TITLE
CHICKEN Packaging - version 0.3

### DIFF
--- a/srfi-128.meta
+++ b/srfi-128.meta
@@ -2,8 +2,13 @@
 
 ((egg "srfi-128.egg")
  ; List of files that should be bundled alongside egg
- (files "comparators"
-        "tests"
+ (files "comparators/comparators.scm"
+        "comparators/comparators-impl.scm"
+        "comparators/comparators-test.scm"
+        "comparators/default.scm"
+        "comparators/r7rs-shim.scm"
+        "comparators/complex-shim.scm"
+        "tests/run.scm"
         "srfi-128.setup"
         "srfi-128.meta"
         "srfi-128.release-info"
@@ -14,8 +19,8 @@
  (category data)
  (depends numbers)
  (test-depends test)
- (author "John Cowan, Egg by Jörg F. Wittenberger / Jeremy Steward")
+ (author "John Cowan")
+ (maintainer "Jeremy Steward, Jörg F. Wittenberger")
  (synopsis "SRFI-128: Comparators (reduced)")
  (email "cowan@ccil.org")
- (repo "https://github.com/scheme-requests-for-implementation/srfi-128")
- (version "0.2"))
+ (repo "https://github.com/scheme-requests-for-implementation/srfi-128"))

--- a/srfi-128.release-info
+++ b/srfi-128.release-info
@@ -1,4 +1,8 @@
+(uri meta-file
+     "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "0.3")
+
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-128.git")
-(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-128/tar.gz/CHICKEN-{egg-release}")
-(release "0.1")
-(release "0.2")
+(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-128/tar.gz/CHICKEN-{egg-release}" whole-repo)
+(release "0.1" whole-repo)
+(release "0.2" whole-repo)

--- a/srfi-128.setup
+++ b/srfi-128.setup
@@ -10,4 +10,4 @@
 (install-extension
  'srfi-128
  `("srfi-128.types" ,(dynld-name "srfi-128") ,(dynld-name "srfi-128.import"))
- '((version "0.2")))
+ '((version "0.3")))


### PR DESCRIPTION
This is done as was the case for [this
pull-request](https://github.com/scheme-requests-for-implementation/srfi-113/pull/5)
in order to better serve the egg without extraneous files.