### PR TITLE
Fixed two bugs and made hashing much faster.

### DIFF
--- a/comparators/comparators-test.scm
+++ b/comparators/comparators-test.scm
@@ -202,6 +202,17 @@
 
   ) ; end comparators/default
 
+  ;; SRFI 128 does not actually require a comparator's four procedures
+  ;; to be eq? to the procedures originally passed to make-comparator.
+  ;; For interoperability/interchangeability between the comparators
+  ;; of SRFI 114 and SRFI 128, some of the procedures passed to
+  ;; make-comparator may need to be wrapped inside another lambda
+  ;; expression before they're returned by the corresponding accessor.
+  ;;
+  ;; So this next group of tests is incorrect, hence commented out
+  ;; and replaced by a slightly less naive group of tests.
+
+#;
   (test-group "comparators/accessors"
     (define ttp (lambda (x) #t))
     (define eqp (lambda (x y) #t))
@@ -212,6 +223,22 @@
     (test eqp (comparator-equality-predicate comp))
     (test orp (comparator-ordering-predicate comp))
     (test hf (comparator-hash-function comp))
+  ) ; end comparators/accessors
+
+  (test-group "comparators/accessors"
+    (define x1 0)
+    (define x2 0)
+    (define x3 0)
+    (define x4 0)
+    (define ttp (lambda (x) (set! x1 111) #t))
+    (define eqp (lambda (x y) (set! x2 222) #t))
+    (define orp (lambda (x y) (set! x3 333) #t))
+    (define hf (lambda (x) (set! x4 444) 0))
+    (define comp (make-comparator ttp eqp orp hf))
+    (test #t (and ((comparator-type-test-predicate comp) x1)   (= x1 111)))
+    (test #t (and ((comparator-equality-predicate comp) x1 x2) (= x2 222)))
+    (test #t (and ((comparator-ordering-predicate comp) x1 x3) (= x3 333)))
+    (test #t (and (zero? ((comparator-hash-function comp) x1)) (= x4 444)))
   ) ; end comparators/accessors
 
   (test-group "comparators/invokers"

--- a/comparators/default.scm
+++ b/comparators/default.scm
@@ -102,8 +102,8 @@
   (let ((a-type (object-type a))
         (b-type (object-type b)))
     (cond
-      ((< a-type b-type) -1)
-      ((> a-type b-type) 1)
+      ((< a-type b-type) #t)
+      ((> a-type b-type) #f)
       (else (dispatch-ordering a-type a b)))))
 
 (define (default-equality a b)

--- a/srfi/128.body2.scm
+++ b/srfi/128.body2.scm
@@ -106,16 +106,20 @@
     ; Add more here
     (else (binary<? (registered-comparator type) a b))))
 
+;;; The author of SRFI 128 has suggested a post-finalization note
+;;; saying the first and third bullet items stating "must" requirements
+;;; for default-hash may be weakened.  That allows a much faster hash
+;;; function to be used for lists and vectors.
+
 (define (default-hash obj)
   (case (object-type obj)
-    ((0) 0)
-    ((1) ((make-pair-hash (make-default-comparator) (make-default-comparator)) obj))
+    ((0 1 7) ; empty list, pair, or vector
+     ((make-hasher) (equal-hash obj)))
     ((2) (boolean-hash obj))
     ((3) (char-hash obj))
     ((4) (string-hash obj))
     ((5) (symbol-hash obj))
     ((6) (number-hash obj))
-    ((7) ((make-vector-hash (make-default-comparator) vector? vector-length vector-ref) obj))
     ((8) ((make-vector-hash (make-default-comparator)
                              bytevector? bytevector-length bytevector-u8-ref) obj))
     ; Add more here
@@ -125,8 +129,8 @@
   (let ((a-type (object-type a))
         (b-type (object-type b)))
     (cond
-      ((< a-type b-type) -1)
-      ((> a-type b-type) 1)
+      ((< a-type b-type) #t)
+      ((> a-type b-type) #f)
       (else (dispatch-ordering a-type a b)))))
 
 (define (default-equality a b)

--- a/srfi/128.sld
+++ b/srfi/128.sld
@@ -19,6 +19,19 @@
           (scheme inexact)
           (scheme complex))
 
+  (cond-expand ((library (srfi 126))
+                (import (only (srfi 126) equal-hash)))
+               ((library (rnrs hashtables))
+                (import (only (rnrs hashtables) equal-hash)))
+               ((library (r6rs hashtables))
+                (import (only (r6rs hashtables) equal-hash)))
+               ((library (srfi 69))
+                (import (rename (only (srfi 69) hash-by-identity)
+                                (hash-by-identity equal-hash))))
+               (else
+                ;; FIXME: This works well enough for the test program,
+                ;; but you wouldn't want to use it in a real program.
+                (begin (define (equal-hash x) 0))))
 
   (include "128.body1.scm")
   (include "128.body2.scm")

--- a/tests/srfi-128-test.sps
+++ b/tests/srfi-128-test.sps
@@ -30,7 +30,7 @@
         (scheme complex)
         (rnrs conditions)
         (rnrs records syntactic)
-        (srfi 116)
+;       (srfi 116)
         (srfi 128))
 
 ;;; Uses "the Chicken test egg, which is provided on Chibi as
@@ -323,7 +323,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (iequal? x y)
-  (cond ((and (ipair? x) (ipair? y))
+  (cond #;
+        ((and (ipair? x) (ipair? y))
          (and (iequal? (icar x) (icar y))
               (iequal? (icdr x) (icdr y))))
         ((and (pair? x) (pair? y))
@@ -622,6 +623,17 @@
 
   ) ; end comparators/default
 
+  ;; SRFI 128 does not actually require a comparator's four procedures
+  ;; to be eq? to the procedures originally passed to make-comparator.
+  ;; For interoperability/interchangeability between the comparators
+  ;; of SRFI 114 and SRFI 128, some of the procedures passed to
+  ;; make-comparator may need to be wrapped inside another lambda
+  ;; expression before they're returned by the corresponding accessor.
+  ;;
+  ;; So this next group of tests is incorrect, hence commented out
+  ;; and replaced by a slightly less naive group of tests.
+
+#;
   (test-group "comparators/accessors"
     (define ttp (lambda (x) #t))
     (define eqp (lambda (x y) #t))
@@ -632,6 +644,22 @@
     (test eqp (comparator-equality-predicate comp))
     (test orp (comparator-ordering-predicate comp))
     (test hf (comparator-hash-function comp))
+  ) ; end comparators/accessors
+
+  (test-group "comparators/accessors"
+    (define x1 0)
+    (define x2 0)
+    (define x3 0)
+    (define x4 0)
+    (define ttp (lambda (x) (set! x1 111) #t))
+    (define eqp (lambda (x y) (set! x2 222) #t))
+    (define orp (lambda (x y) (set! x3 333) #t))
+    (define hf (lambda (x) (set! x4 444) 0))
+    (define comp (make-comparator ttp eqp orp hf))
+    (test #t (and ((comparator-type-test-predicate comp) x1)   (= x1 111)))
+    (test #t (and ((comparator-equality-predicate comp) x1 x2) (= x2 222)))
+    (test #t (and ((comparator-ordering-predicate comp) x1 x3) (= x3 333)))
+    (test #t (and (zero? ((comparator-hash-function comp) x1)) (= x4 444)))
   ) ; end comparators/accessors
 
   (test-group "comparators/invokers"


### PR DESCRIPTION
I haven't tested the non-R7RS code, but I believe I fixed both bugs in the non-R7RS code as well as in the R7RS code.  I did not attempt to improve the speed of hashing in the non-R7RS code because R6RS-style hashtables probably won't be available in systems that can't run R6RS or R7RS code.

SRFI 114 and 128 comparators can be interoperable and interchangeable if implemented properly, but it's a bit tricky and would involve changing both reference implementations in ways that would make one of them dependent on the other.  So I didn't do that in this set of changes.  To see how it can be done, see Larceny's source code for these two SRFIs.