### PR TITLE
Bumps version to accomodate WillClinger's changes

### DIFF
--- a/srfi-128.release-info
+++ b/srfi-128.release-info
@@ -1,6 +1,7 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
 (release "0.3")
+(release "0.4")
 
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-128.git")
 (uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-128/tar.gz/CHICKEN-{egg-release}" whole-repo)

--- a/srfi-128.setup
+++ b/srfi-128.setup
@@ -10,4 +10,4 @@
 (install-extension
  'srfi-128
  `("srfi-128.types" ,(dynld-name "srfi-128") ,(dynld-name "srfi-128.import"))
- '((version "0.3")))
+ '((version "0.4")))


### PR DESCRIPTION
Since the srfi-128 mustard changes that were discussed on the mailing
list, a new version of the egg for CHICKEN has not been published. This
merely bumps the version number for the egg on top of the previous changes
that have been committed.

In addition, could you make a tag for this release as well? Should be `CHICKEN-0.4`. 

Thanks Arthur. 