### PR TITLE
Removes hardcoded .so extension

### DIFF
--- a/srfi-128.release-info
+++ b/srfi-128.release-info
@@ -1,5 +1,6 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "0.6")
 (release "0.5")
 (release "0.4")
 (release "0.3")

--- a/srfi-128.setup
+++ b/srfi-128.setup
@@ -4,10 +4,10 @@
   (make-pathname #f fn ##sys#load-dynamic-extension))
 
 (compile -O3 -d2 -s -J -emit-type-file "srfi-128.types" "comparators/comparators.scm")
-(compile -O3 -d0 -s -J "comparators/comparators.scm" -o srfi-128.so)
+(compile -O3 -d0 -s -J "comparators/comparators.scm" -o ,(dynld-name "srfi-128"))
 (compile -s -O2 -d0 "srfi-128.import.scm")
 
 (install-extension
  'srfi-128
  `("srfi-128.types" ,(dynld-name "srfi-128") ,(dynld-name "srfi-128.import"))
- '((version "0.5")))
+ '((version "0.6")))


### PR DESCRIPTION
Also bumps version to reflect this change

Pointed out by Mario Goulart, this hardcoded file extension could cause issues (although on my tests with Windows, did nothing).

As with others, could you create a tag `CHICKEN-0.6` for this release? Many thanks,