### PR TITLE
library name should be a list

### DIFF
--- a/comparators/comparators.sld
+++ b/comparators/comparators.sld
@@ -1,4 +1,4 @@
-(define-library comparators
+(define-library (comparators)
   (import (scheme base))
   (import (scheme case-lambda))
   (export comparator? comparator-ordered? comparator-hashable?)


### PR DESCRIPTION
Per R7RS section 5.6.1, the <library name> should be a list such as "(generators)" not the single token "generators". CHICKEN seems to be permissive about allowing single token library names, but Chibi is strict.